### PR TITLE
Add `bestItem` and `filterSupportedAppcast` implementation

### DIFF
--- a/Sources/Appcast/SPUAppcastItemStateResolver.swift
+++ b/Sources/Appcast/SPUAppcastItemStateResolver.swift
@@ -36,7 +36,7 @@ public struct SPUAppcastItemStateResolver {
             return maximumVersionOK
         }
         
-        maximumVersionOK = standardVersionComparator.compareVersion(maximumSystemVersion, toVersion: SUOperatingSystem.systemVersionString) != .orderedDescending
+        maximumVersionOK = standardVersionComparator.compareVersion(maximumSystemVersion, toVersion: SUOperatingSystem.systemVersionString) != .orderedAscending
         return maximumVersionOK
     }
 

--- a/Sources/Appcast/SUAppcastDriver.swift
+++ b/Sources/Appcast/SUAppcastDriver.swift
@@ -73,20 +73,12 @@ public class SUAppcastDriver {
         return appcastItem.deltaUpdates[hostVersion]
     }
     
-    public static func bestItem(fromAppcastItems: [SUAppcastItem], getDeltaItem: SUAppcastItem?, withHostVersion: String, comparator: SUVersionComparison) -> SUAppcastItem {
+    public static func bestItem(fromAppcastItems: [SUAppcastItem], getDeltaItem: SUAppcastItem?, withHostVersion: String, comparator: SUVersionComparison) -> SUAppcastItem? {
         var item: SUAppcastItem?
         for appcastItem in fromAppcastItems {
             if item == nil || comparator.compareVersion(item!.versionString, toVersion: appcastItem.versionString) == .orderedAscending {
                 item = appcastItem
             }
-        }
-        return item!
-    }
-    
-    public static func bestItem(fromAppcastItems: [SUAppcastItem], getDeltaItem: inout SUAppcastItem?, withHostVersion: String, comparator: SUVersionComparison) -> SUAppcastItem {
-        let item = bestItem(fromAppcastItems: fromAppcastItems, getDeltaItem: getDeltaItem, withHostVersion: withHostVersion, comparator: comparator)
-        if (getDeltaItem != nil) {
-            getDeltaItem = deltaUpdate(from: item, hostVersion: withHostVersion)
         }
         return item
     }

--- a/Sources/Appcast/SUAppcastDriver.swift
+++ b/Sources/Appcast/SUAppcastDriver.swift
@@ -9,11 +9,11 @@ import Foundation
 
 public class SUAppcastDriver {
     public static func itemIsReadyForPhasedRollout(_ item: SUAppcastItem, phasedUpdateGroup: NSNumber?, currentDate: Date, hostVersion: String, versionComparator: SUVersionComparison) -> Bool {
-        if phasedUpdateGroup == nil || item.isCriticalUpdate {
+        guard let phasedUpdateGroup, !item.isCriticalUpdate else {
             return true
         }
 
-        guard let phasedRolloutInterval = item.phasedRolloutInterval?.doubleValue else {
+        guard let phasedRolloutInterval = item.phasedRolloutInterval else {
             return true
         }
 
@@ -22,9 +22,9 @@ public class SUAppcastDriver {
         }
 
         let timeSinceRelease = currentDate.timeIntervalSince(itemReleaseDate)
-        let timeToWaitForGroup = phasedRolloutInterval * Double(phasedUpdateGroup!.uintValue)
+        let timeToWaitForGroup = phasedRolloutInterval * phasedUpdateGroup.intValue
 
-        return timeSinceRelease >= timeToWaitForGroup
+        return timeSinceRelease >= Double(timeToWaitForGroup)
     }
     
     public static func containsSkippedUpdate(item: SUAppcastItem, skippedUpdate: SPUSkippedUpdate?, hostPassesSkippedMajorVersion: Bool, versionComparator: SUVersionComparison) -> Bool {

--- a/Sources/Appcast/SUAppcastDriver.swift
+++ b/Sources/Appcast/SUAppcastDriver.swift
@@ -8,9 +8,65 @@
 import Foundation
 
 public class SUAppcastDriver {
-    public static func filterSupportedAppcast(_ appcast: SUAppcast, phasedUpdateGroup: NSNumber?, skippedUpdate: Any?, currentDate: Date, hostVersion: String, versionComparator: SUVersionComparison, testOSVersion: Bool, testMinimumAutoupdateVersion: Bool) -> SUAppcast {
-        return appcast
+    public static func itemIsReadyForPhasedRollout(_ item: SUAppcastItem, phasedUpdateGroup: NSNumber?, currentDate: Date, hostVersion: String, versionComparator: SUVersionComparison) -> Bool {
+        if phasedUpdateGroup == nil || item.isCriticalUpdate {
+            return true
+        }
+
+        guard let phasedRolloutInterval = item.phasedRolloutInterval?.doubleValue else {
+            return true
+        }
+
+        guard let itemReleaseDate = item.date else {
+            return true
+        }
+
+        let timeSinceRelease = currentDate.timeIntervalSince(itemReleaseDate)
+        let timeToWaitForGroup = phasedRolloutInterval * Double(phasedUpdateGroup!.uintValue)
+
+        return timeSinceRelease >= timeToWaitForGroup
     }
+    
+    public static func containsSkippedUpdate(item: SUAppcastItem, skippedUpdate: SPUSkippedUpdate?, hostPassesSkippedMajorVersion: Bool, versionComparator: SUVersionComparison) -> Bool {
+        guard let skippedUpdate = skippedUpdate else {
+            return false
+        }
+
+        let skippedMajorVersion = skippedUpdate.majorVersion
+        let skippedMajorSubreleaseVersion = skippedUpdate.majorSubreleaseVersion
+
+        if !hostPassesSkippedMajorVersion, let skippedMajorVersion = skippedMajorVersion, let minimumAutoupdateVersion = item.minimumAutoupdateVersion, versionComparator.compareVersion(skippedMajorVersion, toVersion: minimumAutoupdateVersion) != .orderedAscending, (item.ignoreSkippedUpgradesBelowVersion == nil || (skippedMajorSubreleaseVersion != nil && versionComparator.compareVersion(skippedMajorSubreleaseVersion!, toVersion: item.ignoreSkippedUpgradesBelowVersion!) != .orderedAscending)) {
+            // If skipped major version is >= than the item's minimumAutoupdateVersion, we can skip the item.
+            // But if there is an ignoreSkippedUpgradesBelowVersion, we can only skip the item if the last skipped subrelease
+            // version is >= than that version provided by the item
+            return true
+        }
+
+        if let skippedMinorVersion = skippedUpdate.minorVersion, versionComparator.compareVersion(skippedMinorVersion, toVersion: item.versionString) != .orderedAscending {
+            // Item is on a less or equal version than a minor version we've skipped
+            // So we skip this item
+            return true
+        }
+
+        return false
+    }
+    
+    public static func filterSupportedAppcast(_ appcast: SUAppcast, phasedUpdateGroup: NSNumber?, skippedUpdate: SPUSkippedUpdate?, currentDate: Date, hostVersion: String, versionComparator: SUVersionComparison, testOSVersion: Bool, testMinimumAutoupdateVersion: Bool) -> SUAppcast {
+
+        let hostPassesSkippedMajorVersion = SPUAppcastItemStateResolver.isMinimumAutoupdateVersionOK(skippedUpdate?.majorVersion, hostVersion: hostVersion, versionComparator: versionComparator)
+
+        let filteredItems = appcast.items.filter { item in
+            let passesOSVersion = !testOSVersion || (item.minimumOperatingSystemVersionIsOK && item.maximumOperatingSystemVersionIsOK)
+            let passesPhasedRollout = itemIsReadyForPhasedRollout(item, phasedUpdateGroup: phasedUpdateGroup, currentDate: currentDate, hostVersion: hostVersion, versionComparator: versionComparator)
+            let passesMinimumAutoupdateVersion = !testMinimumAutoupdateVersion || !item.isMajorUpgrade
+            let passesSkippedUpdates = hostVersion.isEmpty || !containsSkippedUpdate(item: item, skippedUpdate: skippedUpdate, hostPassesSkippedMajorVersion: hostPassesSkippedMajorVersion, versionComparator: versionComparator)
+
+            return passesOSVersion && passesPhasedRollout && passesMinimumAutoupdateVersion && passesSkippedUpdates
+        }
+
+        return SUAppcast(items: filteredItems)
+    }
+    
     public static func deltaUpdate(from appcastItem: SUAppcastItem, hostVersion: String) -> SUAppcastItem? {
         return appcastItem.deltaUpdates[hostVersion]
     }

--- a/Sources/Appcast/SUAppcastDriver.swift
+++ b/Sources/Appcast/SUAppcastDriver.swift
@@ -34,12 +34,14 @@ public class SUAppcastDriver {
 
         let skippedMajorVersion = skippedUpdate.majorVersion
         let skippedMajorSubreleaseVersion = skippedUpdate.majorSubreleaseVersion
-
-        if !hostPassesSkippedMajorVersion, let skippedMajorVersion = skippedMajorVersion, let minimumAutoupdateVersion = item.minimumAutoupdateVersion, versionComparator.compareVersion(skippedMajorVersion, toVersion: minimumAutoupdateVersion) != .orderedAscending, (item.ignoreSkippedUpgradesBelowVersion == nil || (skippedMajorSubreleaseVersion != nil && versionComparator.compareVersion(skippedMajorSubreleaseVersion!, toVersion: item.ignoreSkippedUpgradesBelowVersion!) != .orderedAscending)) {
-            // If skipped major version is >= than the item's minimumAutoupdateVersion, we can skip the item.
-            // But if there is an ignoreSkippedUpgradesBelowVersion, we can only skip the item if the last skipped subrelease
-            // version is >= than that version provided by the item
-            return true
+        
+        if !hostPassesSkippedMajorVersion, let skippedMajorVersion, let minimumAutoupdateVersion = item.minimumAutoupdateVersion, let skippedMajorSubreleaseVersion, let ignoreSkippedUpgradesBelowVersion = item.ignoreSkippedUpgradesBelowVersion {
+            if versionComparator.compareVersion(skippedMajorVersion, toVersion: minimumAutoupdateVersion) != .orderedAscending, versionComparator.compareVersion(skippedMajorSubreleaseVersion, toVersion: ignoreSkippedUpgradesBelowVersion) != .orderedAscending {
+                // If skipped major version is >= than the item's minimumAutoupdateVersion, we can skip the item.
+                // But if there is an ignoreSkippedUpgradesBelowVersion, we can only skip the item if the last skipped subrelease
+                // version is >= than that version provided by the item
+                return true
+            }
         }
 
         if let skippedMinorVersion = skippedUpdate.minorVersion, versionComparator.compareVersion(skippedMinorVersion, toVersion: item.versionString) != .orderedAscending {

--- a/Sources/Appcast/SUAppcastDriver.swift
+++ b/Sources/Appcast/SUAppcastDriver.swift
@@ -11,13 +11,26 @@ public class SUAppcastDriver {
     public static func filterSupportedAppcast(_ appcast: SUAppcast, phasedUpdateGroup: NSNumber?, skippedUpdate: Any?, currentDate: Date, hostVersion: String, versionComparator: SUVersionComparison, testOSVersion: Bool, testMinimumAutoupdateVersion: Bool) -> SUAppcast {
         return appcast
     }
+    public static func deltaUpdate(from appcastItem: SUAppcastItem, hostVersion: String) -> SUAppcastItem? {
+        return appcastItem.deltaUpdates[hostVersion]
+    }
     
     public static func bestItem(fromAppcastItems: [SUAppcastItem], getDeltaItem: SUAppcastItem?, withHostVersion: String, comparator: SUVersionComparison) -> SUAppcastItem {
-        return fromAppcastItems.first!
+        var item: SUAppcastItem?
+        for appcastItem in fromAppcastItems {
+            if item == nil || comparator.compareVersion(item!.versionString, toVersion: appcastItem.versionString) == .orderedAscending {
+                item = appcastItem
+            }
+        }
+        return item!
     }
     
     public static func bestItem(fromAppcastItems: [SUAppcastItem], getDeltaItem: inout SUAppcastItem?, withHostVersion: String, comparator: SUVersionComparison) -> SUAppcastItem {
-        return fromAppcastItems.first!
+        let item = bestItem(fromAppcastItems: fromAppcastItems, getDeltaItem: getDeltaItem, withHostVersion: withHostVersion, comparator: comparator)
+        if (getDeltaItem != nil) {
+            getDeltaItem = deltaUpdate(from: item, hostVersion: withHostVersion)
+        }
+        return item
     }
     
     public static func filterAppcast(_ appcast: SUAppcast, forMacOSAndAllowedChannels allowedChannels: [String]) -> SUAppcast {

--- a/Sources/Appcast/SUAppcastItem.swift
+++ b/Sources/Appcast/SUAppcastItem.swift
@@ -267,7 +267,7 @@ public class SUAppcastItem {
      
      Old applications must be using Sparkle 1.25 or later to support phased rollout intervals, otherwise they may assume updates are immediately available.
      */
-    public let phasedRolloutInterval: Int?
+    public let phasedRolloutInterval: NSNumber?
 
     /**
      The minimum bundle version string this update requires for automatically downloading and installing updates if provided.
@@ -599,8 +599,12 @@ public class SUAppcastItem {
             self._state = resolvedState
         }
         
-        let rolloutIntervalString = dict[SUAppcastElement.PhasedRolloutInterval] as? String
-        self.phasedRolloutInterval = Int(rolloutIntervalString ?? "")
+        if let rolloutIntervalString = dict[SUAppcastElement.PhasedRolloutInterval] as? String, let rolloutInterval = Int(rolloutIntervalString) {
+            self.phasedRolloutInterval = NSNumber(value: rolloutInterval)
+        }
+        else {
+            self.phasedRolloutInterval = nil
+        }
         
         // Find the appropriate release notes URL.
         if let releaseNotesLinkString = dict[SUAppcastElement.ReleaseNotesLink] as? String {

--- a/Sources/Appcast/SUAppcastItem.swift
+++ b/Sources/Appcast/SUAppcastItem.swift
@@ -267,7 +267,7 @@ public class SUAppcastItem {
      
      Old applications must be using Sparkle 1.25 or later to support phased rollout intervals, otherwise they may assume updates are immediately available.
      */
-    public let phasedRolloutInterval: NSNumber?
+    public let phasedRolloutInterval: Int?
 
     /**
      The minimum bundle version string this update requires for automatically downloading and installing updates if provided.
@@ -599,12 +599,8 @@ public class SUAppcastItem {
             self._state = resolvedState
         }
         
-        if let rolloutIntervalString = dict[SUAppcastElement.PhasedRolloutInterval] as? String, let rolloutInterval = Int(rolloutIntervalString) {
-            self.phasedRolloutInterval = NSNumber(value: rolloutInterval)
-        }
-        else {
-            self.phasedRolloutInterval = nil
-        }
+        let rolloutIntervalString = dict[SUAppcastElement.PhasedRolloutInterval] as? String
+                self.phasedRolloutInterval = Int(rolloutIntervalString ?? "")
         
         // Find the appropriate release notes URL.
         if let releaseNotesLinkString = dict[SUAppcastElement.ReleaseNotesLink] as? String {

--- a/Tests/IntegrationTests/SUAppcastDriverTests.swift
+++ b/Tests/IntegrationTests/SUAppcastDriverTests.swift
@@ -111,3 +111,13 @@ class SUAppcastDriverTests: XCTestCase {
         XCTAssertNil(nonexistantDeltaItem)
     }
 }
+
+extension SUAppcastDriver {
+    public static func bestItem(fromAppcastItems: [SUAppcastItem], getDeltaItem: inout SUAppcastItem?, withHostVersion: String, comparator: SUVersionComparison) -> SUAppcastItem? {
+        let item = SUAppcastDriver.bestItem(fromAppcastItems: fromAppcastItems, getDeltaItem: getDeltaItem, withHostVersion: withHostVersion, comparator: comparator)
+        if let item, getDeltaItem != nil {
+            getDeltaItem = deltaUpdate(from: item, hostVersion: withHostVersion)
+        }
+        return item
+    }
+}

--- a/Tests/IntegrationTests/SUAppcastMinimumAutoupdateTests.swift
+++ b/Tests/IntegrationTests/SUAppcastMinimumAutoupdateTests.swift
@@ -39,7 +39,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                 
                 let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                 
-                XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                XCTAssertEqual(bestAppcastItem?.versionString, "2.0")
             }
             
             // We should be offered 3.0 if host version is 2.0
@@ -55,7 +55,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                 
                 let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                 
-                XCTAssertEqual(bestAppcastItem.versionString, "3.0")
+                XCTAssertEqual(bestAppcastItem?.versionString, "3.0")
             }
             
             // We should be offered 3.0 if host version is 2.5
@@ -71,7 +71,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                 
                 let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                 
-                XCTAssertEqual(bestAppcastItem.versionString, "3.0")
+                XCTAssertEqual(bestAppcastItem?.versionString, "3.0")
             }
             
             // Because 3.0 has minimum autoupdate version of 2.0, we would be be offered 2.0, but not if it has been skipped
@@ -100,7 +100,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "3.0")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "3.0")
                 }
                 
                 // Allow minimum autoupdate version to fail and only skip 3.0
@@ -113,7 +113,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "2.0")
                 }
                 
                 // Allow minimum autoupdate version to fail skipping both 2.0 and 3.0
@@ -136,7 +136,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "3.0")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "3.0")
                 }
                 
                 // This should not skip anything but require passing minimum autoupdate version
@@ -149,7 +149,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "2.0")
                 }
                 
                 // This should not skip anything but allow failing minimum autoupdate version
@@ -162,7 +162,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "3.0")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "3.0")
                 }
                 
                 // This should not skip anything but require passing minimum autoupdate version
@@ -175,7 +175,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "2.0")
                 }
                 
                 // This should not skip anything but allow failing minimum autoupdate version
@@ -188,7 +188,7 @@ class SUAppcastMinimumAutoupdateTests: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "3.0")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "3.0")
                 }
             }
         } catch let err as NSError {

--- a/Tests/IntegrationTests/SUAppcastTest.swift
+++ b/Tests/IntegrationTests/SUAppcastTest.swift
@@ -39,7 +39,7 @@ class SUAppcastTest: XCTestCase {
                 
                 let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                 
-                XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                XCTAssertEqual(bestAppcastItem?.versionString, "2.0")
             }
             
             // Allow minimum autoupdate version to fail and only skip major version "3.0"
@@ -58,7 +58,7 @@ class SUAppcastTest: XCTestCase {
                 
                 let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                 
-                XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                XCTAssertEqual(bestAppcastItem?.versionString, "4.1")
             }
             
             // Allow minimum autoupdate version to pass and only skip major version "3.0"
@@ -77,7 +77,7 @@ class SUAppcastTest: XCTestCase {
                 
                 let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                 
-                XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                XCTAssertEqual(bestAppcastItem?.versionString, "2.0")
             }
             
             // Allow minimum autoupdate version to fail and only skip major version "4.0"
@@ -96,7 +96,7 @@ class SUAppcastTest: XCTestCase {
                 
                 let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                 
-                XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                XCTAssertEqual(bestAppcastItem?.versionString, "2.0")
             }
         } catch let err as NSError {
             NSLog("%@", err)
@@ -136,7 +136,7 @@ class SUAppcastTest: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "4.1")
                 }
                 
                 // Allow minimum autoupdate version to fail and only skip major version "3.0" with subrelease version 3.4
@@ -155,7 +155,7 @@ class SUAppcastTest: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "4.1")
                 }
                 
                 // Allow minimum autoupdate version to fail and only skip major version "3.0" with subrelease version 3.5
@@ -173,7 +173,7 @@ class SUAppcastTest: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "4.1")
                 }
                 
                 // Allow minimum autoupdate version to fail and only skip major version "3.0" with subrelease version 3.5.1
@@ -191,7 +191,7 @@ class SUAppcastTest: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "4.1")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "4.1")
                 }
                 
                 // Allow minimum autoupdate version to fail and only skip major version "4.0" with subrelease version 4.0
@@ -207,7 +207,7 @@ class SUAppcastTest: XCTestCase {
                     
                     let bestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcast.items, getDeltaItem: nil, withHostVersion: hostVersion, comparator: versionComparator)
                     
-                    XCTAssertEqual(bestAppcastItem.versionString, "2.0")
+                    XCTAssertEqual(bestAppcastItem?.versionString, "2.0")
                 }
                 
                 // Allow minimum autoupdate version to fail and only skip major version "4.0" with subrelease version 4.0, and skip minor version 2.1


### PR DESCRIPTION
There was missing implementation for `bestItem` and `filterSuppostedAppcast` in `SUAppcastDriver`.

I also fixed small bug in `SPUAppcastItemStateResolver::isMaximumOperatingSystemVersionOK`. 