### PR TITLE
Enable Swift strict concurrency checks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .target(
             name: "Appcast",
             swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
+                .enableUpcomingFeature("StrictConcurrency")
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,10 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "Appcast"
+            name: "Appcast",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         ),
         .testTarget(
             name: "AppcastTests",

--- a/Sources/Appcast/SPUAppcastItemState.swift
+++ b/Sources/Appcast/SPUAppcastItemState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct SPUAppcastItemState: Sendable {
+public struct SPUAppcastItemState: Sendable, Equatable {
     public let majorUpgrade: Bool
     public let criticalUpdate: Bool
     public let informationalUpdate: Bool

--- a/Sources/Appcast/SPUAppcastItemState.swift
+++ b/Sources/Appcast/SPUAppcastItemState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct SPUAppcastItemState {
+public struct SPUAppcastItemState: Sendable {
     public let majorUpgrade: Bool
     public let criticalUpdate: Bool
     public let informationalUpdate: Bool

--- a/Sources/Appcast/SPUAppcastItemStateResolver.swift
+++ b/Sources/Appcast/SPUAppcastItemStateResolver.swift
@@ -25,7 +25,8 @@ public struct SPUAppcastItemStateResolver {
             return minimumVersionOK
         }
         
-        minimumVersionOK = standardVersionComparator.compareVersion(minimumSystemVersion, toVersion: SUOperatingSystem.systemVersionString) != .orderedDescending
+        let osVersion = SUOperatingSystem()
+        minimumVersionOK = standardVersionComparator.compareVersion(minimumSystemVersion, toVersion: osVersion.systemVersionString) != .orderedDescending
         return minimumVersionOK
     }
      
@@ -36,7 +37,8 @@ public struct SPUAppcastItemStateResolver {
             return maximumVersionOK
         }
         
-        maximumVersionOK = standardVersionComparator.compareVersion(maximumSystemVersion, toVersion: SUOperatingSystem.systemVersionString) != .orderedAscending
+        let osVersion = SUOperatingSystem()
+        maximumVersionOK = standardVersionComparator.compareVersion(maximumSystemVersion, toVersion: osVersion.systemVersionString) != .orderedAscending
         return maximumVersionOK
     }
 

--- a/Sources/Appcast/SPUDownloadData.swift
+++ b/Sources/Appcast/SPUDownloadData.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A class for containing downloaded data along with some information about it.
-public struct SPUDownloadData {
+public struct SPUDownloadData: Sendable {
     public let data: Data
     public let URL: URL
     public let textEncodingName: String?

--- a/Sources/Appcast/SPUSkippedUpdate.swift
+++ b/Sources/Appcast/SPUSkippedUpdate.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct SPUSkippedUpdate {
+public struct SPUSkippedUpdate: Sendable {
     public let minorVersion: String?
     public let majorVersion: String?
     public let majorSubreleaseVersion: String?

--- a/Sources/Appcast/SUAppcast.swift
+++ b/Sources/Appcast/SUAppcast.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class SUAppcast {
+public struct SUAppcast: Sendable {
     
     internal static let empty = SUAppcast()
     

--- a/Sources/Appcast/SUAppcast.swift
+++ b/Sources/Appcast/SUAppcast.swift
@@ -44,7 +44,7 @@ public class SUAppcast {
 //        }
         
         for item in xmlItems {
-            var dict = [String: Any]()
+            var dict = SUAppcastItemProperties()
             var nodesDict = [String: [XMLNode]]()
             
             if item.childCount > 0 {

--- a/Sources/Appcast/SUOperatingSystem.swift
+++ b/Sources/Appcast/SUOperatingSystem.swift
@@ -7,9 +7,14 @@
 
 import Foundation
 
-public class SUOperatingSystem {
-    public static var systemVersionString: String {
-        let version = ProcessInfo.processInfo.operatingSystemVersion
-        return String(format: "%ld.%ld.%ld", version.majorVersion, version.minorVersion, version.patchVersion)
+public struct SUOperatingSystem: Sendable {
+    public let systemVersionString: String
+    
+    init() {
+        self.init(ProcessInfo.processInfo.operatingSystemVersion)
+    }
+    
+    init(_ version: OperatingSystemVersion) {
+        self.systemVersionString = String(format: "%ld.%ld.%ld", version.majorVersion, version.minorVersion, version.patchVersion)
     }
 }

--- a/Sources/Appcast/SUSignatures.swift
+++ b/Sources/Appcast/SUSignatures.swift
@@ -5,7 +5,7 @@
 // Based on SUSignatures.m from Sparkle project.
 //
 
-public struct SUSignatures {
+public struct SUSignatures: Sendable {
     public let ed25519: String
 
     public init(ed ed25519: String) {

--- a/Sources/Appcast/SUStandardVersionComparator.swift
+++ b/Sources/Appcast/SUStandardVersionComparator.swift
@@ -12,7 +12,7 @@ import Foundation
 /// This comparator is adapted from MacPAD, by Kevin Ballard.
 /// It's "dumb" in that it does essentially string comparison
 /// in components split by character type.
-public struct SUStandardVersionComparator: SUVersionComparison {
+public struct SUStandardVersionComparator: SUVersionComparison, Sendable {
     /// A singleton instance of the comparator.
     public static let `default` = SUStandardVersionComparator()
     

--- a/Tests/AppcastTests/SUAppcastItemBaseTests.swift
+++ b/Tests/AppcastTests/SUAppcastItemBaseTests.swift
@@ -8,8 +8,8 @@ import XCTest
 
 class SUAppcastItemBaseTests: XCTestCase {
     
-    func createBasicAppcastItemDictionary() -> SUAppcastItem.AppcastItemDictionary {
-        var dict = SUAppcastItem.AppcastItemDictionary()
+    func createBasicAppcastItemDictionary() -> SUAppcastItemProperties {
+        var dict = SUAppcastItemProperties()
         dict[SURSSElement.Title] = "Acme v1.0"
         dict[SUAppcastElement.Version] = "1.0.0"
         

--- a/Tests/AppcastTests/SUAppcastItemTests+displayVersionString.swift
+++ b/Tests/AppcastTests/SUAppcastItemTests+displayVersionString.swift
@@ -65,7 +65,7 @@ class SUAppcastItemTests_displayVersionString: SUAppcastItemBaseTests {
     }
     
     func createLegacyAppcastItemWithEnclosureShortVersionString(sparkleVersion: String, sparkleShortVersion: String) throws -> SUAppcastItem {
-        var enclosure = SUAppcastItem.AppcastItemDictionary()
+        var enclosure = SUAppcastItemProperties()
         enclosure[SUAppcastAttribute.ShortVersionString] = sparkleShortVersion
         
         var dict = self.createBasicAppcastItemDictionary()

--- a/Tests/AppcastTests/SUAppcastItemTests+isCriticalUpdate.swift
+++ b/Tests/AppcastTests/SUAppcastItemTests+isCriticalUpdate.swift
@@ -64,7 +64,7 @@ class SUAppcastItemTests_isCriticalUpdate: SUAppcastItemBaseTests {
     }
     
     // MARK: - helper functions
-    func createAppcastItemWithCriticalUpdateDictionary() -> SUAppcastItem.AppcastItemDictionary {
+    func createAppcastItemWithCriticalUpdateDictionary() -> SUAppcastItemProperties {
         var dict = self.createBasicAppcastItemDictionary()
         
         dict[SUAppcastElement.CriticalUpdate] = SUAppcast.AttributesDictionary()
@@ -72,7 +72,7 @@ class SUAppcastItemTests_isCriticalUpdate: SUAppcastItemBaseTests {
         return dict
     }
 
-    func createAppcastItemWithLegacyTagWithCriticalUpdateDictionary() -> SUAppcastItem.AppcastItemDictionary {
+    func createAppcastItemWithLegacyTagWithCriticalUpdateDictionary() -> SUAppcastItemProperties {
         var dict = self.createBasicAppcastItemDictionary()
         
         let tags = [SUAppcastElement.CriticalUpdate]

--- a/Tests/AppcastTests/SUOperatingSystemTests.swift
+++ b/Tests/AppcastTests/SUOperatingSystemTests.swift
@@ -11,12 +11,25 @@ class SUOperatingSystemTests: XCTestCase {
     func test_systemVersionString_matchesExpectedFormat() throws {
         // Arrange
         let expectedFormat = try NSRegularExpression.init(pattern: "\\d+.\\d+.\\d+")
+        let osVersion = SUOperatingSystem()
 
         // Act
-        let actualVersionString = SUOperatingSystem.systemVersionString
+        let actualVersionString = osVersion.systemVersionString
         let actualMatchCount = expectedFormat.numberOfMatches(in: actualVersionString, range: NSMakeRange(0, actualVersionString.count))
         
         // Assert
         XCTAssertEqual(actualMatchCount, 1)
+    }
+    
+    func test_systemVersionString_matchesProvidedOperatingSystemVersionValue() throws {
+        // Arrange
+        let mockVersion = OperatingSystemVersion(majorVersion: 15, minorVersion: 3, patchVersion: 2)
+        let osVersion = SUOperatingSystem(mockVersion)
+
+        // Act
+        let actualVersionString = osVersion.systemVersionString
+        
+        // Assert
+        XCTAssertEqual(actualVersionString, "15.3.2")
     }
 }

--- a/Tests/IntegrationTests/SUAppcastDriverTests.swift
+++ b/Tests/IntegrationTests/SUAppcastDriverTests.swift
@@ -61,7 +61,7 @@ class SUAppcastDriverTests: XCTestCase {
         let actualBestAppcastItem = SUAppcastDriver.bestItem(fromAppcastItems: supportedAppcastItems, getDeltaItem: &deltaItem, withHostVersion: hostVersion, comparator: self.versionComparator)
 
         // Arrange
-        XCTAssertIdentical(actualBestAppcastItem, supportedAppcastItems[1])
+        XCTAssertEqual(actualBestAppcastItem, supportedAppcastItems[1])
     }
     
     /// Test latest delta update item available


### PR DESCRIPTION
Makes the `Appcast` library compatible with Swift 6 strict concurrency checks.

### Breaking Changes
- The `SUAppcastItem` struct no longer exposes the `propertiesDictionary` dictionary
- Many classes were changed to structs

---
Implements #7 