### PR TITLE
Fix parsing of the `<description sparkle:format="">` attribute value

### DIFF
--- a/Sources/Appcast/SUAppcastItem.swift
+++ b/Sources/Appcast/SUAppcastItem.swift
@@ -524,7 +524,7 @@ public struct SUAppcastItem: Sendable, Equatable {
         let descriptionDict = dict[SURSSElement.Description] as? SUAppcast.AttributesDictionary
         
         self.itemDescription = descriptionDict?["content"] as? String
-        self.itemDescriptionFormat = descriptionDict?["format"] as? String ?? self.itemDescription != nil ? "html" : nil
+        self.itemDescriptionFormat = descriptionDict?["format"] as? String ?? (self.itemDescription != nil ? "html" : nil)
         
         if let infoUrlString = dict[SURSSElement.Link] as? String {
             guard let infoUrl = URL(string: infoUrlString, relativeTo: appcastURL) else {


### PR DESCRIPTION
Fixes the test `IntegrationTests.SUAppcastParserTest test_items_item0`.

The original code was evaluated like this:

```swift 
print (descriptionDict?["format"] as? String ?? self.itemDescription) != nil
(Bool) true

print (descriptionDict?["format"] as? String ?? self.itemDescription) != nil ? "html" : nil
(String?) "html"
```

Fixes #10 