### PR TITLE
Define code owners

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,7 @@
+# Appcast package code owners
+
+# Appcast source code is owned by @slidoapp/team-presentations team
+* @DominikPalo @jozefizso @m-kovac @filipbodor 
+
+# CODEOWNERS definitions are owned by admins from @slidoapp/team-presentations-admins team
+.github/CODEOWNERS @DominikPalo @jozefizso


### PR DESCRIPTION
I had to explicitly list team members because even though teams are set to public visibility, they are visible only to members of the `slidoapp` org.