### PR TITLE
Fix the resolved state information for legacy critical update definition

### DIFF
--- a/Sources/Appcast/SUAppcastItem.swift
+++ b/Sources/Appcast/SUAppcastItem.swift
@@ -591,10 +591,15 @@ public struct SUAppcastItem: Sendable, Equatable {
         }
         
         // Grab critical update information
-        let criticalUpdateDict = dict[SUAppcastElement.CriticalUpdate] as? SUAppcast.AttributesDictionary
+        var criticalUpdateDict = dict[SUAppcastElement.CriticalUpdate] as? SUAppcast.AttributesDictionary
         let tags = dict[SUAppcastElement.Tags] as? [String]
         let hasCriticalTag = tags?.contains(SUAppcastElement.CriticalUpdate) ?? false
-        self._hasCriticalInformation = criticalUpdateDict != nil || hasCriticalTag
+        if hasCriticalTag {
+            // Legacy path where critical update used to be a tag without a specified version
+            criticalUpdateDict = .init()
+        }
+        
+        self._hasCriticalInformation = criticalUpdateDict != nil
         
         if let stateResolver {
             self._state = stateResolver.resolveState(informationalUpdateVersions: self._informationalUpdateVersions, minimumOperatingSystemVersion: self.minimumSystemVersion, maximumOperatingSystemVersion: self.maximumSystemVersion, minimumAutoupdateVersion: self.minimumAutoupdateVersion, criticalUpdateDictionary: criticalUpdateDict)

--- a/Tests/IntegrationTests/SUAppcastParserTests.swift
+++ b/Tests/IntegrationTests/SUAppcastParserTests.swift
@@ -54,7 +54,6 @@ class SUAppcastParserTest: XCTestCase {
         XCTAssertEqual("desc3", actualItem.itemDescription)
         XCTAssertEqual("html", actualItem.itemDescriptionFormat)
         XCTAssertNil(actualItem.dateString)
-        // TODO: legacy critical update information inside <sparkle:tags> element is not implemented yet
         XCTAssertTrue(actualItem.isCriticalUpdate)
         XCTAssertEqual(actualItem.phasedRolloutInterval, 86400)
         XCTAssertEqual(actualItem.versionString, "3.0")


### PR DESCRIPTION
Fixes the resolved state information for an Appcast item by passing an empty `SUAppcast.AttributesDictionary` when the legacy critical update is defined like this:

```xml
<sparkle:tags><sparkle:criticalUpdate /></sparkle:tags>
```