### PR TITLE
chore: Add CODEOWNERS file with @sli-do/team-presentations ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sli-do/team-presentations


### PR DESCRIPTION
This PR adds a CODEOWNERS file to establish proper code ownership for this repository.

## Changes
- Added `.github/CODEOWNERS` file with `@sli-do/team-presentations` as the owner
- This ensures that all changes require review from the appropriate team

## Impact  
- Improves code review process
- Establishes clear ownership responsibilities
- Aligns with repository governance standards