### PR TITLE
Migrate Appcast library to Swift 6 toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,17 +13,14 @@ jobs:
   build:
     strategy:
       matrix:
-        swift: ['swift6.0', 'swift5.10', 'swift5.9']
+        swift: ['swift-6.1', 'swift-6.2']
         include:
-          - swift: 'swift6.0'
-            xcode-path: '/Applications/Xcode_16.1.0.app'
+          - swift: 'swift-6.1'
+            xcode-path: '/Applications/Xcode_16.4.0.app'
             macos: 'macos-15'
-          - swift: 'swift5.10'
-            xcode-path: '/Applications/Xcode_15.4.0.app'
-            macos: 'macos-14'
-          - swift: 'swift5.9'
-            xcode-path: '/Applications/Xcode_15.2.0.app'
-            macos: 'macos-14'
+          - swift: 'swift-6.2'
+            xcode-path: '/Applications/Xcode_26.2.0.app'
+            macos: 'macos-15'
     
     env:
       DEVELOPER_DIR: ${{ matrix.xcode-path }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 6.1
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Appcast library is a Swift package to work with Sparkle compatible appcast files
 
 ## Installation
 
-Requires Swift 5.8.
+Requires Swift 6.1 (Xcode 16.4 or newer).
 
 
 ### Swift Package Manager


### PR DESCRIPTION
Require at least Swift 6.1 / Xcode 16.4 toolchain.

This aligns the requirements with the Apple App Store Connect guidelines.