### PR TITLE
Rewrite unit tests to use Swift Testing framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       id: results-unit-tests
       with:
         name: 'results-unit-tests-${{ matrix.swift }}'
-        path: reports/AppcastTests.xml
+        path: reports/AppcastTests-swift-testing.xml
         reporter: swift-xunit
         fail-on-error: true
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         swift: ['swift-6.1', 'swift-6.2']
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,13 @@ jobs:
       run: swift test --filter='AppcastTests' --parallel --xunit-output reports/AppcastTests.xml
   
     - name: report unit test results
-      uses: dorny/test-reporter@afe6793191b75b608954023a46831a3fe10048d4
+      uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0
       if: always()
       id: results-unit-tests
       with:
         name: 'results-unit-tests-${{ matrix.swift }}'
         path: reports/AppcastTests.xml
-        reporter: java-junit
+        reporter: swift-xunit
         fail-on-error: true
   
     - name: run integration tests
@@ -60,13 +60,13 @@ jobs:
       run: swift test --filter='IntegrationTests' --parallel --xunit-output reports/IntegrationTests.xml || true
 
     - name: report integration test results
-      uses: dorny/test-reporter@afe6793191b75b608954023a46831a3fe10048d4
+      uses: dorny/test-reporter@fe45e9537387dac839af0d33ba56eed8e24189e8 # v2.3.0
       if: always()
       id: results-integration-tests
       with:
         name: 'results-integration-tests-${{ matrix.swift }}'
         path: reports/IntegrationTests.xml
-        reporter: java-junit
+        reporter: swift-xunit
         fail-on-error: false
   
     - name: summary

--- a/Tests/AppcastTests/AlwaysPassTests.swift
+++ b/Tests/AppcastTests/AlwaysPassTests.swift
@@ -3,12 +3,12 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Testing
 @testable import Appcast
 
 /// Ensures at least one unit test will pass.
-final class AlwaysPassTests: XCTestCase {
-    func test_alwaysPass() throws {
-        XCTAssertTrue(true, "This test will always pass.")
+struct AlwaysPassTests {
+    @Test func alwaysPass() {
+        #expect(Bool(true), "This test will always pass.")
     }
 }

--- a/Tests/AppcastTests/SPUAppcastItemStateTests.swift
+++ b/Tests/AppcastTests/SPUAppcastItemStateTests.swift
@@ -3,21 +3,21 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Testing
 @testable import Appcast
 
-class SPUAppcastItemStateTests: XCTestCase {
+struct SPUAppcastItemStateTests {
 
-    func test_init() throws {
+    @Test func init_SPUAppcastItemState() throws {
         // Arrange
         // Act
         let itemState = SPUAppcastItemState(withMajorUpgrade: true, criticalUpdate: true, informationalUpdate: true, minimumOperatingSystemVersionIsOK: true, maximumOperatingSystemVersionIsOK: true)
 
         // Assert
-        XCTAssertTrue(itemState.majorUpgrade)
-        XCTAssertTrue(itemState.criticalUpdate)
-        XCTAssertTrue(itemState.informationalUpdate)
-        XCTAssertTrue(itemState.minimumOperatingSystemVersionIsOK)
-        XCTAssertTrue(itemState.maximumOperatingSystemVersionIsOK)
+        #expect(itemState.majorUpgrade)
+        #expect(itemState.criticalUpdate)
+        #expect(itemState.informationalUpdate)
+        #expect(itemState.minimumOperatingSystemVersionIsOK)
+        #expect(itemState.maximumOperatingSystemVersionIsOK)
     }
 }

--- a/Tests/AppcastTests/SPUDownloadDataTests.swift
+++ b/Tests/AppcastTests/SPUDownloadDataTests.swift
@@ -3,12 +3,13 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import Appcast
 
-class SPUDownloadDataTests: XCTestCase {
+struct SPUDownloadDataTests {
 
-    func test_init() throws {
+    @Test func init_SPUDownloadData() throws {
         // Arrange
         let data = Data()
         let url = URL(string: "https://example.org")!
@@ -19,9 +20,9 @@ class SPUDownloadDataTests: XCTestCase {
         let downloadData = SPUDownloadData(withData: data, URL: url, textEncodingName: textEncodingName, MIMEType: mimeType)
 
         // Assert
-        XCTAssertEqual(downloadData.data, data)
-        XCTAssertEqual(downloadData.URL, url)
-        XCTAssertEqual(downloadData.textEncodingName, textEncodingName)
-        XCTAssertEqual(downloadData.MIMEType, mimeType)
+        #expect(downloadData.data == data)
+        #expect(downloadData.URL == url)
+        #expect(downloadData.textEncodingName == textEncodingName)
+        #expect(downloadData.MIMEType == mimeType)
     }
 }

--- a/Tests/AppcastTests/SUAppcastItemBaseTests.swift
+++ b/Tests/AppcastTests/SUAppcastItemBaseTests.swift
@@ -3,11 +3,10 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Testing
 @testable import Appcast
 
-class SUAppcastItemBaseTests: XCTestCase {
-    
+class SUAppcastItemBaseTests {
     func createBasicAppcastItemDictionary() -> SUAppcastItemProperties {
         var dict = SUAppcastItemProperties()
         dict[SURSSElement.Title] = "Acme v1.0"

--- a/Tests/AppcastTests/SUAppcastItemTests+displayVersionString.swift
+++ b/Tests/AppcastTests/SUAppcastItemTests+displayVersionString.swift
@@ -3,13 +3,13 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Testing
 @testable import Appcast
 
-class SUAppcastItemTests_displayVersionString: SUAppcastItemBaseTests {
+final class SUAppcastItemTests_displayVersionString: SUAppcastItemBaseTests {
     // MARK: displayVersionString() tests
     /// When update has only the `<sparkle:version>` element the ``SUAppcastItem.displayVersionString`` value is equal to the ``SUAppcastItem.versionString`` value.
-    func test_displayVersionString_appcastWithoutSparkleShortVersionStringValue() throws {
+    @Test func displayVersionString_appcastWithoutSparkleShortVersionStringValue() throws {
         // Arrange
         let item = try self.createAppcastItemWithShortVersionString(sparkleVersion: "1.4.8", sparkleShortVersion: nil)
         
@@ -18,12 +18,12 @@ class SUAppcastItemTests_displayVersionString: SUAppcastItemBaseTests {
         let displayVersion = item.displayVersionString
         
         // Assert
-        XCTAssertEqual("1.4.8", version)
-        XCTAssertEqual(version, displayVersion)
+        #expect("1.4.8" == version)
+        #expect(version == displayVersion)
     }
     
     /// When update has the `<sparkle:sparkleShortVersion>` element, use it for the ``SUAppcastItem.displayVersionString`` value.
-    func test_displayVersionString_appcastWithSparkleShortVersionStringElement() throws {
+    @Test func displayVersionString_appcastWithSparkleShortVersionStringElement() throws {
         // Arrange
         let item = try self.createAppcastItemWithShortVersionString(sparkleVersion: "1799", sparkleShortVersion: "2.3.0")
         
@@ -32,13 +32,13 @@ class SUAppcastItemTests_displayVersionString: SUAppcastItemBaseTests {
         let displayVersion = item.displayVersionString
         
         // Assert
-        XCTAssertEqual("1799", version)
-        XCTAssertEqual("2.3.0", displayVersion)
+        #expect("1799" == version)
+        #expect("2.3.0" == displayVersion)
     }
     
     /// Sparkle 1.0 supports the `<enclosure sparkle:shortVersionString="1.0.2">` attribute.
     /// This value is prefered over the `<sparkle:sparkleShortVersion>` element based on the original implementation.
-    func test_displayVersionString_enclosureElementWithShortVersionStringAttribute() throws {
+    @Test func displayVersionString_enclosureElementWithShortVersionStringAttribute() throws {
         // Arrange
         let item = try self.createLegacyAppcastItemWithEnclosureShortVersionString(sparkleVersion: "1430", sparkleShortVersion: "1.0.2")
         
@@ -47,8 +47,8 @@ class SUAppcastItemTests_displayVersionString: SUAppcastItemBaseTests {
         let displayVersion = item.displayVersionString
         
         // Assert
-        XCTAssertEqual("1430", version)
-        XCTAssertEqual("1.0.2", displayVersion)
+        #expect("1430" == version)
+        #expect("1.0.2" == displayVersion)
     }
 
     // MARK: helper methods for creating test data

--- a/Tests/AppcastTests/SUAppcastItemTests+isCriticalUpdate.swift
+++ b/Tests/AppcastTests/SUAppcastItemTests+isCriticalUpdate.swift
@@ -3,12 +3,12 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Testing
 @testable import Appcast
 
-class SUAppcastItemTests_isCriticalUpdate: SUAppcastItemBaseTests {
+final class SUAppcastItemTests_isCriticalUpdate: SUAppcastItemBaseTests {
     // MARK: isCriticalUpdate() tests
-    func test_isCriticalUpdate_nilState_isFalseByDefault() throws {
+    @Test func isCriticalUpdate_nilState_isFalseByDefault() throws {
         // Arrange
         let expectedResolvedState: SPUAppcastItemState? = nil
         let dict = self.createBasicAppcastItemDictionary()
@@ -19,10 +19,10 @@ class SUAppcastItemTests_isCriticalUpdate: SUAppcastItemBaseTests {
         let actualCriticalUpdate = item.isCriticalUpdate
         
         // Assert
-        XCTAssertFalse(actualCriticalUpdate)
+        #expect(!actualCriticalUpdate)
     }
     
-    func test_isCriticalUpdate_stateWithCriticalUpdate_isTrue() throws {
+    @Test func isCriticalUpdate_stateWithCriticalUpdate_isTrue() throws {
         // Arrange
         let expectedResolvedState = SPUAppcastItemState(withMajorUpgrade: false, criticalUpdate: true, informationalUpdate: false, minimumOperatingSystemVersionIsOK: false, maximumOperatingSystemVersionIsOK: false)
         let dict = self.createBasicAppcastItemDictionary()
@@ -33,10 +33,10 @@ class SUAppcastItemTests_isCriticalUpdate: SUAppcastItemBaseTests {
         let actualCriticalUpdate = item.isCriticalUpdate
         
         // Assert
-        XCTAssertTrue(actualCriticalUpdate)
+        #expect(actualCriticalUpdate)
     }
     
-    func test_isCriticalUpdate_dictionaryWithCriticalUpdateInformation_isTrue() throws {
+    @Test func isCriticalUpdate_dictionaryWithCriticalUpdateInformation_isTrue() throws {
         // Arrange
         let dict = self.createAppcastItemWithCriticalUpdateDictionary()
 
@@ -46,10 +46,10 @@ class SUAppcastItemTests_isCriticalUpdate: SUAppcastItemBaseTests {
         let actualCriticalUpdate = item.isCriticalUpdate
         
         // Assert
-        XCTAssertTrue(actualCriticalUpdate)
+        #expect(actualCriticalUpdate)
     }
     
-    func test_isCriticalUpdate_legacyCriticalUpdateInformationInTag_isTrue() throws {
+    @Test func isCriticalUpdate_legacyCriticalUpdateInformationInTag_isTrue() throws {
         // Arrange
         let dict = self.createAppcastItemWithLegacyTagWithCriticalUpdateDictionary()
 
@@ -59,8 +59,8 @@ class SUAppcastItemTests_isCriticalUpdate: SUAppcastItemBaseTests {
         let actualCriticalUpdate = item.isCriticalUpdate
         
         // Assert
-        try XCTSkipUnless(actualCriticalUpdate, "Legacy format of critical updates in the <sparkle:tags> element are not supported.")
-        XCTAssertTrue(actualCriticalUpdate)
+        //try XCTSkipUnless(actualCriticalUpdate, "Legacy format of critical updates in the <sparkle:tags> element are not supported.")
+        #expect(actualCriticalUpdate)
     }
     
     // MARK: - helper functions

--- a/Tests/AppcastTests/SUAppcastItemTests+isInformationOnlyUpdate.swift
+++ b/Tests/AppcastTests/SUAppcastItemTests+isInformationOnlyUpdate.swift
@@ -3,12 +3,12 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Testing
 @testable import Appcast
 
-class SUAppcastItemTests_isInformationOnlyUpdate: SUAppcastItemBaseTests {
+final class SUAppcastItemTests_isInformationOnlyUpdate: SUAppcastItemBaseTests {
     // MARK: isInformationOnlyUpdate() tests
-    func test_isInformationOnlyUpdate_nilState_isFalseByDefault() throws {
+    @Test func isInformationOnlyUpdate_nilState_isFalseByDefault() throws {
         let expectedResolvedState: SPUAppcastItemState? = nil
         let dict = self.createBasicAppcastItemDictionary()
         
@@ -18,10 +18,10 @@ class SUAppcastItemTests_isInformationOnlyUpdate: SUAppcastItemBaseTests {
         let actualInformationOnlyUpdate = item.isInformationOnlyUpdate
         
         // Assert
-        XCTAssertFalse(actualInformationOnlyUpdate)
+        #expect(!actualInformationOnlyUpdate)
     }
     
-    func test_isInformationOnlyUpdate_stateWithInformationOnlyUpdate_isTrue() throws {
+    @Test func isInformationOnlyUpdate_stateWithInformationOnlyUpdate_isTrue() throws {
         let expectedResolvedState = SPUAppcastItemState(withMajorUpgrade: false, criticalUpdate: true, informationalUpdate: true, minimumOperatingSystemVersionIsOK: false, maximumOperatingSystemVersionIsOK: false)
         
         let dict = self.createBasicAppcastItemDictionary()
@@ -31,6 +31,6 @@ class SUAppcastItemTests_isInformationOnlyUpdate: SUAppcastItemBaseTests {
         let actualInformationOnlyUpdate = item.isInformationOnlyUpdate
         
         // Assert
-        XCTAssertTrue(actualInformationOnlyUpdate)
+        #expect(actualInformationOnlyUpdate)
     }
 }

--- a/Tests/AppcastTests/SUAppcastItemTests+isMajorUpgrade.swift
+++ b/Tests/AppcastTests/SUAppcastItemTests+isMajorUpgrade.swift
@@ -3,12 +3,12 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Testing
 @testable import Appcast
 
-class SUAppcastItemTests_isMajorUpgrade: SUAppcastItemBaseTests {
+final class SUAppcastItemTests_isMajorUpgrade: SUAppcastItemBaseTests {
     // MARK: isMajorUpgrade() tests
-    func test_isMajorUpgrade_noResolvedState_isFalseByDefault() throws {
+    @Test func isMajorUpgrade_noResolvedState_isFalseByDefault() throws {
         let expectedResolvedState: SPUAppcastItemState? = nil
         let dict = self.createBasicAppcastItemDictionary()
         
@@ -18,10 +18,10 @@ class SUAppcastItemTests_isMajorUpgrade: SUAppcastItemBaseTests {
         let actualMajorUpgrade = item.isMajorUpgrade
         
         // Assert
-        XCTAssertFalse(actualMajorUpgrade)
+        #expect(!actualMajorUpgrade, "Appcast item must hase isMajorUpgrade set to false")
     }
     
-    func test_isMajorUpgrade_stateWithMajorUpgrade_isTrue() throws {
+    @Test func isMajorUpgrade_stateWithMajorUpgrade_isTrue() throws {
         let expectedResolvedState = SPUAppcastItemState(withMajorUpgrade: true, criticalUpdate: false, informationalUpdate: false, minimumOperatingSystemVersionIsOK: false, maximumOperatingSystemVersionIsOK: false)
         
         let dict = self.createBasicAppcastItemDictionary()
@@ -31,6 +31,6 @@ class SUAppcastItemTests_isMajorUpgrade: SUAppcastItemBaseTests {
         let actualMajorUpgrade = item.isMajorUpgrade
         
         // Assert
-        XCTAssertTrue(actualMajorUpgrade)
+        #expect(actualMajorUpgrade, "Appcast item must hase isMajorUpgrade set to true")
     }
 }

--- a/Tests/AppcastTests/SUAppcastTests.swift
+++ b/Tests/AppcastTests/SUAppcastTests.swift
@@ -3,11 +3,12 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import Appcast
 
-final class SUAppcastTests: XCTestCase {
-    func test_init_simpleAppcastFile() throws {
+struct SUAppcastTests {
+    @Test func init_simpleAppcastFile() throws {
         // Arrange
         let expectedItemsCount = 1
         
@@ -20,10 +21,10 @@ final class SUAppcastTests: XCTestCase {
         let actualItemsCount = appcast.items.count
         
         // Assert
-        XCTAssertEqual(actualItemsCount, expectedItemsCount)
+        #expect(actualItemsCount == expectedItemsCount)
     }
     
-    func test_items_simpleAppcast_createsAppcastItem() throws {
+    @Test func items_simpleAppcast_createsAppcastItem() throws {
         // Arrange
         let appcastResource = Bundle.module.url(forResource: "appcast_simple", withExtension: "xml")!
         let appcastData = try Data(contentsOf: appcastResource)
@@ -34,66 +35,66 @@ final class SUAppcastTests: XCTestCase {
         let actualAppcastItem = appcast.items.first
         
         // Assert
-        XCTAssertNotNil(actualAppcastItem)
-        XCTAssertEqual(actualAppcastItem?.title, "Version 2.0")
-        XCTAssertEqual(actualAppcastItem?.versionString, "2.0")
+        #expect(actualAppcastItem != nil)
+        #expect(actualAppcastItem?.title == "Version 2.0")
+        #expect(actualAppcastItem?.versionString == "2.0")
     }
     
-    func test_date_parsedFromDateString() throws {
+    @Test func date_parsedFromDateString() throws {
         // Arrange
         let appcastResource = Bundle.module.url(forResource: "appcast_simple", withExtension: "xml")!
         let appcastData = try Data(contentsOf: appcastResource)
-        
+
         let appcast = try SUAppcast(xmlData: appcastData, relativeTo: nil, stateResolver: nil)
-        
+
         // Act
         let actualAppcastItem = appcast.items.first
-        
+
         // Assert
-        XCTAssertNotNil(actualAppcastItem)
-        XCTAssertEqual(actualAppcastItem?.dateString, "Sat, 26 Jul 2014 15:20:11 +0000")
-        XCTAssertNotNil(actualAppcastItem?.date)
-        
+        #expect(actualAppcastItem != nil)
+        #expect(actualAppcastItem?.dateString == "Sat, 26 Jul 2014 15:20:11 +0000")
+        #expect(actualAppcastItem?.date != nil)
+
         // Verify the date was parsed correctly (in UTC timezone)
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!
         let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: actualAppcastItem!.date!)
-        XCTAssertEqual(components.year, 2014)
-        XCTAssertEqual(components.month, 7)
-        XCTAssertEqual(components.day, 26)
-        XCTAssertEqual(components.hour, 15)
-        XCTAssertEqual(components.minute, 20)
-        XCTAssertEqual(components.second, 11)
+        #expect(components.year == 2014)
+        #expect(components.month == 7)
+        #expect(components.day == 26)
+        #expect(components.hour == 15)
+        #expect(components.minute == 20)
+        #expect(components.second == 11)
     }
     
-    func test_copyByFilteringItems_filterByVersionValue_returnsSingleItem() throws {
+    @Test func copyByFilteringItems_filterByVersionValue_returnsSingleItem() throws {
         // Arrange
         let appcastResource = Bundle.module.url(forResource: "appcast_simple", withExtension: "xml")!
         let appcastData = try Data(contentsOf: appcastResource)
-        
+
         let appcast = try SUAppcast(xmlData: appcastData, relativeTo: nil, stateResolver: nil)
-        
+
         // Act - filter to only items with version "2.0"
         let filteredAppcast = appcast.copyByFilteringItems { item in
             item.versionString == "2.0"
         }
-        
+
         // Assert
-        XCTAssertEqual(filteredAppcast.items.count, 1)
-        XCTAssertEqual(filteredAppcast.items.first?.versionString, "2.0")
+        #expect(filteredAppcast.items.count == 1)
+        #expect(filteredAppcast.items.first?.versionString == "2.0")
     }
     
-    func test_copyByFilteringItems_filterIsFalsePredicate_returnsNoneItems() throws {
+    @Test func copyByFilteringItems_filterIsFalsePredicate_returnsNoneItems() throws {
         // Arrange
         let appcastResource = Bundle.module.url(forResource: "appcast_simple", withExtension: "xml")!
         let appcastData = try Data(contentsOf: appcastResource)
-        
+
         let appcast = try SUAppcast(xmlData: appcastData, relativeTo: nil, stateResolver: nil)
-        
+
         // Act - filter to empty
         let emptyAppcast = appcast.copyByFilteringItems { _ in false }
-        
+
         // Assert
-        XCTAssertEqual(emptyAppcast.items.count, 0)
+        #expect(emptyAppcast.items.count == 0)
     }
 }

--- a/Tests/AppcastTests/SUOperatingSystemTests.swift
+++ b/Tests/AppcastTests/SUOperatingSystemTests.swift
@@ -3,12 +3,13 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Foundation
+import Testing
 @testable import Appcast
 
-class SUOperatingSystemTests: XCTestCase {
+struct SUOperatingSystemTests {
 
-    func test_systemVersionString_matchesExpectedFormat() throws {
+    @Test func systemVersionString_matchesExpectedFormat() throws {
         // Arrange
         let expectedFormat = try NSRegularExpression.init(pattern: "\\d+.\\d+.\\d+")
         let osVersion = SUOperatingSystem()
@@ -18,10 +19,10 @@ class SUOperatingSystemTests: XCTestCase {
         let actualMatchCount = expectedFormat.numberOfMatches(in: actualVersionString, range: NSMakeRange(0, actualVersionString.count))
         
         // Assert
-        XCTAssertEqual(actualMatchCount, 1)
+        #expect(actualMatchCount == 1)
     }
     
-    func test_systemVersionString_matchesProvidedOperatingSystemVersionValue() throws {
+    @Test func systemVersionString_matchesProvidedOperatingSystemVersionValue() throws {
         // Arrange
         let mockVersion = OperatingSystemVersion(majorVersion: 15, minorVersion: 3, patchVersion: 2)
         let osVersion = SUOperatingSystem(mockVersion)
@@ -30,6 +31,6 @@ class SUOperatingSystemTests: XCTestCase {
         let actualVersionString = osVersion.systemVersionString
         
         // Assert
-        XCTAssertEqual(actualVersionString, "15.3.2")
+        #expect(actualVersionString == "15.3.2")
     }
 }

--- a/Tests/AppcastTests/SUStandardVersionComparatorTests.swift
+++ b/Tests/AppcastTests/SUStandardVersionComparatorTests.swift
@@ -3,89 +3,73 @@
 // Licensed under MIT-style license (see LICENSE.txt file).
 //
 
-import XCTest
+import Testing
 @testable import Appcast
 
-class SUStandardVersionComparatorTests: XCTestCase {
-    func test_init_standardComparatorCanBeInitialized() throws {
-        // Arrange & Act
-        let actualtComparator = SUStandardVersionComparator()
-        
-        // Assert
-        XCTAssertNotNil(actualtComparator)
-    }
-
-    func test_default_comparatorIsAccessibleFromSwift() throws {
-        // Arrange & Act
-        let actualDefaultComparator = SUStandardVersionComparator.default
-        
-        // Assert
-        XCTAssertNotNil(actualDefaultComparator)
-    }
-    
+struct SUStandardVersionComparatorTests  {
     // MARK: func typeOfCharacter(_ character: String) tests
-    func test_typeOfCharacter_periodSeparator() {
+    @Test func typeOfCharacter_periodSeparator() {
         let comparator = SUStandardVersionComparator()
         
         // Act
         let actualCharacterType = comparator.typeOfCharacter(".")
         
         // Assert
-        XCTAssertEqual(actualCharacterType, SUStandardVersionComparator.SUCharacterType.periodSeparatorType)
+        #expect(actualCharacterType == SUStandardVersionComparator.SUCharacterType.periodSeparatorType)
     }
     
-    func test_typeOfCharacter_dash() {
+    @Test func typeOfCharacter_dash() {
         let comparator = SUStandardVersionComparator()
         
         // Act
         let actualCharacterType = comparator.typeOfCharacter("-")
         
         // Assert
-        XCTAssertEqual(actualCharacterType, SUStandardVersionComparator.SUCharacterType.dashType)
+        #expect(actualCharacterType == SUStandardVersionComparator.SUCharacterType.dashType)
     }
     
-    func test_typeOfCharacter_number() {
+    @Test func typeOfCharacter_number() {
         let comparator = SUStandardVersionComparator()
         
         // Act
         let actualCharacterType = comparator.typeOfCharacter("1")
         
         // Assert
-        XCTAssertEqual(actualCharacterType, SUStandardVersionComparator.SUCharacterType.numberType)
+        #expect(actualCharacterType == SUStandardVersionComparator.SUCharacterType.numberType)
     }
     
-    func test_typeOfCharacter_whitespace() {
+    @Test func typeOfCharacter_whitespace() {
         let comparator = SUStandardVersionComparator()
         
         // Act
         let actualCharacterType = comparator.typeOfCharacter(" ")
         
         // Assert
-        XCTAssertEqual(actualCharacterType, SUStandardVersionComparator.SUCharacterType.whitespaceSeparatorType)
+        #expect(actualCharacterType == SUStandardVersionComparator.SUCharacterType.whitespaceSeparatorType)
     }
     
-    func test_typeOfCharacter_punctuationSeparator() {
+    @Test func typeOfCharacter_punctuationSeparator() {
         let comparator = SUStandardVersionComparator()
         
         // Act
         let actualCharacterType = comparator.typeOfCharacter("(")
         
         // Assert
-        XCTAssertEqual(actualCharacterType, SUStandardVersionComparator.SUCharacterType.punctuationSeparatorType)
+        #expect(actualCharacterType == SUStandardVersionComparator.SUCharacterType.punctuationSeparatorType)
     }
     
-    func test_typeOfCharacter_string() {
+    @Test func typeOfCharacter_string() {
         let comparator = SUStandardVersionComparator()
         
         // Act
         let actualCharacterType = comparator.typeOfCharacter("")
         
         // Assert
-        XCTAssertEqual(actualCharacterType, SUStandardVersionComparator.SUCharacterType.stringType)
+        #expect(actualCharacterType == SUStandardVersionComparator.SUCharacterType.stringType)
     }
     
     // MARK: func countOfNumberAndPeriodStartingParts tests
-    func test_countOfNumberAndPeriodStartingParts_simpleNumericVersion() {
+    @Test func countOfNumberAndPeriodStartingParts_simpleNumericVersion() {
         let comparator = SUStandardVersionComparator()
         let parts = ["1", ".", "0"]
         
@@ -93,11 +77,11 @@ class SUStandardVersionComparatorTests: XCTestCase {
         let actualCount = comparator.countOfNumberAndPeriodStartingParts(parts)
         
         // Assert
-        XCTAssertEqual(actualCount, 3)
+        #expect(actualCount == 3)
     }
     
     // MARK: func splitVersion
-    func test_splitVersion() {
+    @Test func splitVersion() {
         let expectedParts = ["1", ".", "23", ".", "19", " ", "(", "1234", ")"]
         let comparator = SUStandardVersionComparator()
         
@@ -105,7 +89,7 @@ class SUStandardVersionComparatorTests: XCTestCase {
         let actualParts = comparator.splitVersion(string: "1.23.19 (1234)")
         
         // Assert
-        XCTAssertEqual(actualParts.count, 9)
-        XCTAssertEqual(actualParts, expectedParts)
+        #expect(actualParts.count == 9)
+        #expect(actualParts == expectedParts)
     }
 }


### PR DESCRIPTION
We are refactoring unit tests in the `Tests/AppcastTests` folder from XCTest to Swift Testing framework.

Integration tests are still using XCTest because they should match original Sparkle implementation more closely.

Implements #9 