### PR TITLE
Enable the Swift 5.10 target again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,11 @@ jobs:
   build:
     strategy:
       matrix:
-        swift: ['swift-6.1', 'swift-6.2']
+        swift: ['swift-5.10', 'swift-6.1', 'swift-6.2']
         include:
+          - swift: 'swift-5.10'
+            xcode-path: '/Applications/Xcode_15.4.0.app'
+            macos: 'macos-14'
           - swift: 'swift-6.1'
             xcode-path: '/Applications/Xcode_16.4.0.app'
             macos: 'macos-15'

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 5.10
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Appcast library is a Swift package to work with Sparkle compatible appcast files
 
 ## Installation
 
-Requires Swift 6.1 (Xcode 16.4 or newer).
+Requires Swift 5.10 or 6.1 (Xcode 16.4 or newer).
 
 
 ### Swift Package Manager


### PR DESCRIPTION
The main project will use the Appcast library in is still targeting the Swift 5.10 toolchain.

Relates to the #26 