### PR TITLE
Sanitized disallowed characters in the channel names

### DIFF
--- a/Sources/Appcast/SUAppcastItem.swift
+++ b/Sources/Appcast/SUAppcastItem.swift
@@ -25,6 +25,32 @@ public struct SUAppcastItem: Sendable, Equatable {
     public static let empty = SUAppcastItem()
     
     /**
+     Allowed characters for custom channel names.
+     
+     The allowed characters are alphanumeric characters and @c _ @c . @c -.
+     */
+    public static let allowedChannelCharacterSet: CharacterSet = {
+        var allowedCharacterSet = CharacterSet.alphanumerics
+        allowedCharacterSet.insert(charactersIn: "_.-")
+        return allowedCharacterSet
+    }()
+    
+    /**
+     Sanitizes a channel name by replacing each invalid character with @c __.
+     */
+    public static func sanitizeChannelName(_ channelName: String) -> String {
+        var sanitizedScalars = String.UnicodeScalarView()
+        for scalar in channelName.unicodeScalars {
+            if Self.allowedChannelCharacterSet.contains(scalar) {
+                sanitizedScalars.append(scalar)
+            } else {
+                sanitizedScalars.append(contentsOf: "__".unicodeScalars)
+            }
+        }
+        return String(sanitizedScalars)
+    }
+    
+    /**
      The version of the update item.
      
      Sparkle uses this property to compare update items and determine the best available update item in the `SUAppcast`.
@@ -703,11 +729,8 @@ public struct SUAppcastItem: Sendable, Equatable {
               !channel.isEmpty else {
             return nil
         }
-        
-        var channelAllowedCharacterSet = CharacterSet.alphanumerics
-        channelAllowedCharacterSet.insert(charactersIn: "_.-")
-        
-        if channel.rangeOfCharacter(from: channelAllowedCharacterSet.inverted) != nil {
+
+        if channel.rangeOfCharacter(from: Self.allowedChannelCharacterSet.inverted) != nil {
             return nil
         }
         

--- a/Tests/AppcastTests/SUAppcastItemTests+sanitizeChannelName.swift
+++ b/Tests/AppcastTests/SUAppcastItemTests+sanitizeChannelName.swift
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 Cisco Systems, Inc. All rights reserved.
+// Licensed under MIT-style license (see LICENSE.txt file).
+//
+
+import XCTest
+@testable import Appcast
+
+class SUAppcastItemTests_sanitizeChannelName: SUAppcastItemBaseTests {
+    func test_allowedChannelCharacterSet_containsExpectedCharacters() {
+        let allowedCharacterSet = SUAppcastItem.allowedChannelCharacterSet
+        
+        XCTAssertTrue(allowedCharacterSet.contains("a".unicodeScalars.first!))
+        XCTAssertTrue(allowedCharacterSet.contains("Z".unicodeScalars.first!))
+        XCTAssertTrue(allowedCharacterSet.contains("0".unicodeScalars.first!))
+        XCTAssertTrue(allowedCharacterSet.contains("_".unicodeScalars.first!))
+        XCTAssertTrue(allowedCharacterSet.contains(".".unicodeScalars.first!))
+        XCTAssertTrue(allowedCharacterSet.contains("-".unicodeScalars.first!))
+        XCTAssertFalse(allowedCharacterSet.contains(" ".unicodeScalars.first!))
+        XCTAssertFalse(allowedCharacterSet.contains("/".unicodeScalars.first!))
+    }
+    
+    func test_sanitizeChannelName_validValue_returnsSameValue() {
+        let channelName = SUAppcastItem.sanitizeChannelName("beta_1.2-3")
+        XCTAssertEqual("beta_1.2-3", channelName)
+    }
+    
+    func test_sanitizeChannelName_invalidWhitespace_replacedWithDoubleUnderscore() {
+        let channelName = SUAppcastItem.sanitizeChannelName("beta channel")
+        XCTAssertEqual("beta__channel", channelName)
+    }
+    
+    func test_sanitizeChannelName_invalidSlash_replacedWithDoubleUnderscore() {
+        let channelName = SUAppcastItem.sanitizeChannelName("beta/channel")
+        XCTAssertEqual("beta__channel", channelName)
+    }
+    
+    func test_sanitizeChannelName_multipleInvalidCharacters_eachReplaced() {
+        let channelName = SUAppcastItem.sanitizeChannelName("beta / nightly")
+        XCTAssertEqual("beta______nightly", channelName)
+    }
+    
+    func test_channel_fromDictionary_validChannel_returnsValue() throws {
+        var dict = self.createBasicAppcastItemDictionary()
+        dict[SUAppcastElement.Channel] = "nightly-2"
+        
+        let item = try SUAppcastItem(dictionary: dict, relativeTo: nil, stateResolver: nil, resolvedState: nil)
+        
+        XCTAssertEqual("nightly-2", item.channel)
+    }
+    
+    func test_channel_fromDictionary_invalidChannel_returnsNil() throws {
+        var dict = self.createBasicAppcastItemDictionary()
+        dict[SUAppcastElement.Channel] = "nightly channel"
+        
+        let item = try SUAppcastItem(dictionary: dict, relativeTo: nil, stateResolver: nil, resolvedState: nil)
+        
+        XCTAssertNil(item.channel)
+    }
+}


### PR DESCRIPTION
Create public `SUAppcastItem.sanitizeChannelName()` function to sanitized disallowed characters in the channel names.
This helps consumers of the Appcast library to generate valid channel names.